### PR TITLE
add py3.6 test & delete multiple macos env

### DIFF
--- a/.github/workflows/Linux_CI.yml
+++ b/.github/workflows/Linux_CI.yml
@@ -5,9 +5,9 @@ name: Linux CI
 
 on:
   push:
-    branches: [ master, brainpy-2.x ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, brainpy-2.x ]
+    branches: [ master ]
 
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/MacOS_CI.yml
+++ b/.github/workflows/MacOS_CI.yml
@@ -5,18 +5,17 @@ name: MacOS CI
 
 on:
   push:
-    branches: [ master, brainpy-2.x ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, brainpy-2.x ]
+    branches: [ master ]
 
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-latest]
         python-version: ["3.7", "3.8", "3.9"]
 
     steps:

--- a/.github/workflows/Windows_CI.yml
+++ b/.github/workflows/Windows_CI.yml
@@ -5,9 +5,9 @@ name: Windows CI
 
 on:
   push:
-    branches: [ master, brainpy-2.x ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, brainpy-2.x ]
+    branches: [ master ]
 
 
 jobs:


### PR DESCRIPTION
## Description
add python 3.6 test on Linux and simplify macOS CI.

## Notice 
This PR is not stable, so this branch will continuously update until all bugs are fixed.