### PR TITLE
JIT errors do not change Variable values

### DIFF
--- a/brainpy/math/autograd.py
+++ b/brainpy/math/autograd.py
@@ -16,7 +16,7 @@ from jax.tree_util import tree_flatten, tree_unflatten, tree_map, tree_transpose
 from jax.util import safe_map
 
 from brainpy import errors
-from brainpy.math.jaxarray import JaxArray, turn_on_global_jit, turn_off_global_jit
+from brainpy.math.jaxarray import JaxArray
 
 __all__ = [
   'grad',  # gradient of scalar function
@@ -33,19 +33,15 @@ def _make_cls_call_func(grad_func, grad_tree, grad_vars, dyn_vars,
     old_grad_vs = [v.value for v in grad_vars]
     old_dyn_vs = [v.value for v in dyn_vars]
     try:
-      turn_on_global_jit()
       grads, (outputs, new_grad_vs, new_dyn_vs) = grad_func(old_grad_vs,
                                                             old_dyn_vs,
                                                             *args,
                                                             **kwargs)
-      turn_off_global_jit()
     except UnexpectedTracerError as e:
-      turn_off_global_jit()
       for v, d in zip(grad_vars, old_grad_vs): v.value = d
       for v, d in zip(dyn_vars, old_dyn_vs): v.value = d
       raise errors.JaxTracerError(variables=dyn_vars + grad_vars) from e
     except Exception as e:
-      turn_off_global_jit()
       for v, d in zip(grad_vars, old_grad_vs): v.value = d
       for v, d in zip(dyn_vars, old_dyn_vs): v.value = d
       raise e

--- a/brainpy/math/autograd.py
+++ b/brainpy/math/autograd.py
@@ -16,7 +16,7 @@ from jax.tree_util import tree_flatten, tree_unflatten, tree_map, tree_transpose
 from jax.util import safe_map
 
 from brainpy import errors
-from brainpy.math.jaxarray import JaxArray
+from brainpy.math.jaxarray import JaxArray, turn_on_global_jit, turn_off_global_jit
 
 __all__ = [
   'grad',  # gradient of scalar function
@@ -33,14 +33,22 @@ def _make_cls_call_func(grad_func, grad_tree, grad_vars, dyn_vars,
     old_grad_vs = [v.value for v in grad_vars]
     old_dyn_vs = [v.value for v in dyn_vars]
     try:
+      turn_on_global_jit()
       grads, (outputs, new_grad_vs, new_dyn_vs) = grad_func(old_grad_vs,
                                                             old_dyn_vs,
                                                             *args,
                                                             **kwargs)
+      turn_off_global_jit()
     except UnexpectedTracerError as e:
+      turn_off_global_jit()
       for v, d in zip(grad_vars, old_grad_vs): v.value = d
       for v, d in zip(dyn_vars, old_dyn_vs): v.value = d
       raise errors.JaxTracerError(variables=dyn_vars + grad_vars) from e
+    except Exception as e:
+      turn_off_global_jit()
+      for v, d in zip(grad_vars, old_grad_vs): v.value = d
+      for v, d in zip(dyn_vars, old_dyn_vs): v.value = d
+      raise e
     for v, d in zip(grad_vars, new_grad_vs): v.value = d
     for v, d in zip(dyn_vars, new_dyn_vs): v.value = d
 

--- a/brainpy/math/jit.py
+++ b/brainpy/math/jit.py
@@ -30,7 +30,7 @@ __all__ = [
 logger = logging.getLogger('brainpy.math.jit')
 
 
-def _make_jit(func, vars, static_argnames=None, device=None, f_name=None):
+def _make_jit_with_vars(func, vars, static_argnames=None, device=None, f_name=None):
   @functools.partial(jax.jit, static_argnames=static_argnames, device=device)
   def jitted_func(variable_data, *args, **kwargs):
     vars.assign(variable_data)
@@ -46,14 +46,30 @@ def _make_jit(func, vars, static_argnames=None, device=None, f_name=None):
       turn_off_global_jit()
     except UnexpectedTracerError as e:
       turn_off_global_jit()
-      # vars.assign(variable_data)
+      vars.assign(variable_data)
       raise errors.JaxTracerError(variables=vars) from e
     except ConcretizationTypeError as e:
       turn_off_global_jit()
-      # vars.assign(variable_data)
+      vars.assign(variable_data)
       raise errors.ConcretizationTypeError() from e
+    except Exception as e:
+      turn_off_global_jit()
+      vars.assign(variable_data)
+      raise e
     vars.assign(changes)
     return out
+
+  return change_func_name(name=f_name, f=call) if f_name else call
+
+
+def _make_jit_without_vars(func, static_argnames=None, device=None, f_name=None):
+  jit_f = jax.jit(func, static_argnames=static_argnames, device=device)
+
+  def call(*args, **kwargs):
+    turn_on_global_jit()
+    r = jit_f(*args, **kwargs)
+    turn_off_global_jit()
+    return r
 
   return change_func_name(name=f_name, f=call) if f_name else call
 
@@ -194,15 +210,13 @@ def jit(func, dyn_vars=None, static_argnames=None, device=None, auto_infer=True)
         dyn_vars = TensorCollector()
 
     if len(dyn_vars) == 0:  # pure function
-      return jax.jit(func,
-                     static_argnames=static_argnames,
-                     device=device)
+      return _make_jit_without_vars(func, static_argnames=static_argnames, device=device)
 
     else:  # Base object which implements __call__, or bounded method of Base object
-      return _make_jit(vars=dyn_vars,
-                       func=func,
-                       static_argnames=static_argnames,
-                       device=device)
+      return _make_jit_with_vars(vars=dyn_vars,
+                                 func=func,
+                                 static_argnames=static_argnames,
+                                 device=device)
 
   else:
     raise errors.BrainPyError(f'Only support instance of {Base.__name__}, or a callable '


### PR DESCRIPTION
Previously, errors occured in JIT function will change value contents of all variables. 

```python

>>> import brainpy.math as bm
>>>
>>> a = bm.Variable(bm.zeros(1))
>>> a = bm.zeros(1)
>>> @bm.jit
>>> def f():
>>>    a.value += 1
>>>    b.value += 1
>>> f()
brainpy.errors.MathError: JaxArray created outside of the jit function cannot be updated in JIT mode. You should mark it as brainpy.math.Variable instead.
>>> a
Variable(Traced<ShapedArray(float32[1])>with<DynamicJaxprTrace(level=0/1)>)

```

Now, the content will keep the same. For example, 

```python

>>> import brainpy.math as bm
>>>
>>> a = bm.Variable(bm.zeros(1))
>>> a = bm.zeros(1)
>>> @bm.jit
>>> def f():
>>>    a.value += 1
>>>    b.value += 1
>>> f()
brainpy.errors.MathError: JaxArray created outside of the jit function cannot be updated in JIT mode. You should mark it as brainpy.math.Variable instead.
>>> a
Variable([0.], dtype=float32)

```
