### PR TITLE
only update local delays of synapse groups

### DIFF
--- a/brainpy/dyn/base.py
+++ b/brainpy/dyn/base.py
@@ -581,7 +581,7 @@ class Network(Container):
       node.update(shared)
 
     # update delays
-    self.update_local_delays(nodes)
+    self.update_local_delays(synapse_groups)
 
   def reset_state(self, batch_size=None):
     nodes = self.nodes(level=1, include_self=False).subset(DynamicalSystem).unique()


### PR DESCRIPTION
## Description
Only updating synapse groups' local delays is needed during Network updating instead of updating all nodes' local delays.

## How I test
Take running 'run_model_v1' in Brette_2007_COBA.py as an example, 6 nodes' local delays would be traversed before this commit. After this commit, 4 nodes' local delays would be traversed.

